### PR TITLE
Align configuration with paper parameters

### DIFF
--- a/configs/exp1_no_rewire.json
+++ b/configs/exp1_no_rewire.json
@@ -1,10 +1,15 @@
 {
   "env": {
-    "num_sats": 8,
-    "num_steps": 5,
+    "num_sats": 172,
+    "num_steps": 200,
     "step_seconds": 60,
     "num_flows": 2,
-    "flow_rate_bps": 100000000
+    "flow_rate_bps": 1600000,
+    "packet_size_bytes": 1500,
+    "queue_cap_pkts": 640,
+    "retransmissions": 3,
+    "w1": 0.5,
+    "w2": 0.5
   },
   "rewiring": {
     "mode": "none"

--- a/configs/exp2_static_rewire.json
+++ b/configs/exp2_static_rewire.json
@@ -1,14 +1,20 @@
 {
   "env": {
-    "num_sats": 8,
-    "num_steps": 5,
+    "num_sats": 172,
+    "num_steps": 200,
     "step_seconds": 60,
     "num_flows": 2,
-    "flow_rate_bps": 100000000
+    "flow_rate_bps": 1600000,
+    "packet_size_bytes": 1500,
+    "queue_cap_pkts": 640,
+    "retransmissions": 3,
+    "w1": 0.5,
+    "w2": 0.5
   },
   "rewiring": {
     "mode": "static",
     "budget_mode": "fraction",
-    "budget": 0.1
+    "budget": 0.1,
+    "alpha": 0.3
   }
 }

--- a/configs/exp3_dynamic_rewire.json
+++ b/configs/exp3_dynamic_rewire.json
@@ -1,14 +1,20 @@
 {
   "env": {
-    "num_sats": 8,
-    "num_steps": 5,
+    "num_sats": 172,
+    "num_steps": 200,
     "step_seconds": 60,
     "num_flows": 2,
-    "flow_rate_bps": 100000000
+    "flow_rate_bps": 1600000,
+    "packet_size_bytes": 1500,
+    "queue_cap_pkts": 640,
+    "retransmissions": 3,
+    "w1": 0.5,
+    "w2": 0.5
   },
   "rewiring": {
     "mode": "dynamic",
     "budget_mode": "fraction",
-    "budget": 0.1
+    "budget": 0.1,
+    "alpha": 0.3
   }
 }

--- a/marl/env.py
+++ b/marl/env.py
@@ -25,10 +25,12 @@ class EnvConfig:
     bandwidth_mhz: float = 25.0
 
     num_flows: int = 4
-    flow_rate_bps: float = 1e8
-    packet_size_bytes: int = 640
-    queue_cap_pkts: int = 500
-    retransmissions: int = 5
+    flow_rate_bps: float = 1.6e6
+    packet_size_bytes: int = 1500
+    queue_cap_pkts: int = 640
+    retransmissions: int = 3
+    w1: float = 0.5
+    w2: float = 0.5
     max_hops: int = 32
 
 
@@ -150,8 +152,8 @@ class MultiSatEnv:
         overflow = sum(self.G_phys[u][v].get("D_pkts", 0.0) for u, v in self.G_phys.edges)
 
         reward = (
-            1.0 * metrics["system_throughput_bps"] / 1e9
-            - 1.0 * metrics["avg_delivery_time_s"]
+            self.cfg.w1 * metrics["system_throughput_bps"] / 1e9
+            - self.cfg.w2 * metrics["avg_delivery_time_s"]
             - 0.01 * overflow
             - 1.0 * loop_penalty
         )


### PR DESCRIPTION
## Summary
- set default environment parameters to match paper: 25 MHz links, 1500-byte packets, 640-packet queues, 3 retransmissions, 1.6 Mbps flow rate, and reward weights w1=w2=0.5
- expose these parameters in experiment configs and run duration set to 200 minutes
- ensure rewiring configs explicitly use compression factor alpha=0.3

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be9196a838832b8afc308628cb797d