### PR TITLE
Add config for polar 560 km constellation

### DIFF
--- a/configs/polar_560km_97.6deg.json
+++ b/configs/polar_560km_97.6deg.json
@@ -1,0 +1,19 @@
+{
+  "env": {
+    "num_sats": 172,
+    "num_steps": 200,
+    "step_seconds": 60,
+    "altitude_km": 560,
+    "inclination_deg": 97.6,
+    "num_flows": 2,
+    "flow_rate_bps": 1600000,
+    "packet_size_bytes": 1500,
+    "queue_cap_pkts": 640,
+    "retransmissions": 3,
+    "w1": 0.5,
+    "w2": 0.5
+  },
+  "rewiring": {
+    "mode": "none"
+  }
+}


### PR DESCRIPTION
## Summary
- add `configs/polar_560km_97.6deg.json` for 172-satellite constellation at 560 km altitude and 97.6° inclination

## Testing
- `python -m scripts.run_mappo --config configs/polar_560km_97.6deg.json --updates 1 --rollout 1` *(fails: ModuleNotFoundError: No module named 'networkx')*
- `pip install networkx numpy torch` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_e_68be94f5e070832bb90435a00f07d03b