### PR TITLE
Add ground station traffic generator

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,19 @@
 """Utility modules for CurvMARL."""
 
-from .traffic import Flow, update_loss_and_queue, aggregate_metrics
+from .traffic import (
+    Flow,
+    update_loss_and_queue,
+    aggregate_metrics,
+    GroundStation,
+    GROUND_STATIONS,
+    GroundStationTraffic,
+)
 
-__all__ = ["Flow", "update_loss_and_queue", "aggregate_metrics"]
+__all__ = [
+    "Flow",
+    "update_loss_and_queue",
+    "aggregate_metrics",
+    "GroundStation",
+    "GROUND_STATIONS",
+    "GroundStationTraffic",
+]


### PR DESCRIPTION
## Summary
- define fixed ground station list with lat/lon coordinates
- implement Pareto-based flow generator that picks new destinations after each flow completes

## Testing
- `python -m pytest`
- `pip install networkx` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bea2655038832b845c9365d52fadbd