### PR TITLE
Add Poisson-based ground station traffic generator

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ from .traffic import (
     GroundStation,
     GROUND_STATIONS,
     GroundStationTraffic,
+    GroundStationPoissonTraffic,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "GroundStation",
     "GROUND_STATIONS",
     "GroundStationTraffic",
+    "GroundStationPoissonTraffic",
 ]


### PR DESCRIPTION
## Summary
- add `GroundStationPoissonTraffic` to simulate Poisson arrivals of Pareto-sized flows with 512KB minimum size
- expose new traffic generator via `utils` package

## Testing
- `python -m py_compile utils/traffic.py utils/__init__.py`
- `pip install networkx` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_e_68bedda86d70832ba1a9b81689ce8426