### PR TITLE
Add GraphPR and CurvMARL entry scripts with shortest-path test

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ Example:
 ```bash
 python scripts/run_shortest_path.py --steps 3 --beta 0.5
 ```
+
+## Algorithm entry points
+
+`scripts/run_graphpr.py` demonstrates the `graph_pr` shortest-path routine on a JSON edge list:
+
+```bash
+python scripts/run_graphpr.py --graph example_graph.json --src A --dst C
+```
+
+`scripts/run_curvmarl.py` launches the MAPPO-based CurvMARL training using a configuration file:
+
+```bash
+python scripts/run_curvmarl.py --config configs/exp1_no_rewire.json
+```

--- a/baselines/graphpr.py
+++ b/baselines/graphpr.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict, Hashable, List
+import heapq
+
+Graph = Dict[Hashable, Dict[Hashable, float]]
+
+def graph_pr(graph: Graph, src: Hashable, dst: Hashable) -> List[Hashable]:
+    """Compute the shortest path between two nodes using Dijkstra's algorithm.
+
+    The graph is represented as a nested mapping where ``graph[u][v]`` is the
+    weight of the edge from ``u`` to ``v``.  The function returns the sequence of
+    nodes on the minimum-cost path from ``src`` to ``dst``.
+    """
+    pq = [(0.0, src, [])]
+    visited = set()
+    while pq:
+        cost, node, path = heapq.heappop(pq)
+        if node in visited:
+            continue
+        visited.add(node)
+        path = path + [node]
+        if node == dst:
+            return path
+        for nbr, w in graph.get(node, {}).items():
+            if nbr not in visited:
+                heapq.heappush(pq, (cost + w, nbr, path))
+    raise ValueError(f"No path from {src} to {dst}")

--- a/scripts/run_curvmarl.py
+++ b/scripts/run_curvmarl.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from scripts.run_mappo import main
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_graphpr.py
+++ b/scripts/run_graphpr.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from baselines.graphpr import graph_pr
+
+
+def load_graph(path: str):
+    with open(path, 'r') as f:
+        data = json.load(f)
+    graph = {}
+    for u, v, w in data:
+        graph.setdefault(u, {})[v] = w
+        graph.setdefault(v, {})[u] = w
+    return graph
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run GraphPR shortest path algorithm')
+    parser.add_argument('--graph', required=True, help='Path to JSON edge list')
+    parser.add_argument('--src', required=True, help='Source node')
+    parser.add_argument('--dst', required=True, help='Destination node')
+    args = parser.parse_args()
+
+    graph = load_graph(args.graph)
+    path = graph_pr(graph, args.src, args.dst)
+    print(' -> '.join(map(str, path)))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_shortest_path.py
+++ b/tests/test_shortest_path.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from baselines.graphpr import graph_pr
+
+
+def test_graphpr_shortest_path():
+    graph = {
+        'A': {'B': 1, 'C': 5},
+        'B': {'A': 1, 'C': 2},
+        'C': {'A': 5, 'B': 2},
+    }
+    assert graph_pr(graph, 'A', 'C') == ['A', 'B', 'C']


### PR DESCRIPTION
## Summary
- implement simple Dijkstra-based `graph_pr` routine
- add command line entry scripts for GraphPR and CurvMARL
- document new entry points and provide a unit test for `graph_pr`

## Testing
- `pytest tests/test_shortest_path.py -q`
- `python scripts/run_graphpr.py --graph /tmp/graph.json --src A --dst C`
- `python scripts/run_curvmarl.py --config configs/exp1_no_rewire.json --updates 1 --rollout 1` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68bee787a310832bb32171d88d6a63b4