### PR TITLE
Add average packet delay metric

### DIFF
--- a/scripts/run_shortest_path.py
+++ b/scripts/run_shortest_path.py
@@ -123,6 +123,7 @@ def main() -> None:
 
     dt_s = float(cfg.step_seconds)
     throughputs: List[float] = []
+    pkt_delays: List[float] = []
     for step in range(args.steps):
         G_t = builder.build_G_t(step)
         H = graph_to_nx(G_t)
@@ -148,10 +149,15 @@ def main() -> None:
         )
         metrics = aggregate_metrics(flows, results)
         throughputs.append(metrics["system_throughput_Mbps"])
+        pkt_delays.append(metrics["avg_packet_delay_s"])
         print(f"step {step}: {metrics}")
 
     avg_thr = sum(throughputs) / len(throughputs) if throughputs else 0.0
+    avg_pkt_delay = sum(pkt_delays) / len(pkt_delays) if pkt_delays else 0.0
     print(f"Average system throughput over {args.steps} steps: {avg_thr:.3f} Mbps")
+    print(
+        f"Average packet transmission delay over {args.steps} steps: {avg_pkt_delay:.6f} s"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track per-flow average packet delay (flow completion time divided by packet count)
- report system-wide average packet delay in shortest-path simulation

## Testing
- `pytest -q`
- `python scripts/run_shortest_path.py --steps 1 -q` *(fails: ModuleNotFoundError: No module named 'networkx')*
- `pip install networkx -q` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa5505748832b9189ba207495b5b4