### PR TITLE
Add average hop count metric

### DIFF
--- a/scripts/run_shortest_path.py
+++ b/scripts/run_shortest_path.py
@@ -129,6 +129,7 @@ def main() -> None:
     dt_s = float(cfg.step_seconds)
     throughputs: List[float] = []
     plrs: List[float] = []
+    hop_counts: List[float] = []
     flow_delays_ms: Dict[int, float] = {}
     for step in range(args.steps):
         G_t = builder.build_G_t(step)
@@ -158,6 +159,7 @@ def main() -> None:
         metrics.pop("avg_delivery_time_s", None)
         throughputs.append(metrics["system_throughput_Mbps"])
         plrs.append(metrics["packet_loss_rate"])
+        hop_counts.append(metrics["avg_hop_count"])
         for r in results:
             fid = r.get("flow_id")
             if fid is not None and fid not in flow_delays_ms:
@@ -167,9 +169,11 @@ def main() -> None:
 
     avg_plr = sum(plrs) / len(plrs) if plrs else 0.0
     avg_thr = sum(throughputs) / len(throughputs) if throughputs else 0.0
+    avg_hops = sum(hop_counts) / len(hop_counts) if hop_counts else 0.0
     avg_pkt_delay_ms = sum(flow_delays_ms.values()) / len(flow_delays_ms) if flow_delays_ms else 0.0
     print(f"Average packet loss rate over {args.steps} steps: {avg_plr:.2f}%")
     print(f"Average system throughput over {args.steps} steps: {avg_thr:.3f} Mbps")
+    print(f"Average hop count over {args.steps} steps: {avg_hops:.2f}")
     print(
         f"Average packet transmission delay over {args.steps} steps: {avg_pkt_delay_ms:.3f} ms",
     )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import Flow, aggregate_metrics
+
+
+def test_aggregate_metrics_avg_hops():
+    flows = [
+        Flow(id=0, src=0, dst=2, rate_bps=0.0, path_edges=[(0, 1), (1, 2)]),
+        Flow(id=1, src=3, dst=4, rate_bps=0.0, path_edges=[(3, 5), (5, 4)]),
+    ]
+    results = [
+        {"goodput_bps": 1.0, "latency_s": 0.0},
+        {"goodput_bps": 1.0, "latency_s": 0.0},
+    ]
+    metrics = aggregate_metrics(flows, results)
+    assert metrics["avg_hop_count"] == 2.0


### PR DESCRIPTION
## Summary
- compute and report average hop count across flows
- show hop count in shortest-path baseline output
- test metric aggregation for hop count

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfc9d5d9ec832bbe281cc7b57e602d