### PR TITLE
Add utilities for average flow statistics

### DIFF
--- a/scripts/flow_stats.py
+++ b/scripts/flow_stats.py
@@ -1,0 +1,20 @@
+"""Print average flow statistics for the default traffic model."""
+
+from utils import GroundStationPoissonTraffic
+
+
+def main() -> None:
+    traffic = GroundStationPoissonTraffic(
+        rate_bps=1.6e6,
+        pareto_shape=1.5,
+        pareto_scale_bytes=512 * 1024,
+        mean_flows_per_min=5.0,
+    )
+    avg_size = traffic.average_flow_size_bytes()
+    avg_rate = traffic.average_rate_bps()
+    print(f"Average flow size: {avg_size:.0f} bytes")
+    print(f"Average end-to-end transmission rate: {avg_rate/1e6:.1f} Mbps")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_flow_stats.py
+++ b/tests/test_flow_stats.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import GroundStationPoissonTraffic
+
+
+def test_average_flow_stats():
+    traffic = GroundStationPoissonTraffic(
+        rate_bps=1.6e6, pareto_shape=1.5, pareto_scale_bytes=512 * 1024
+    )
+    assert traffic.average_rate_bps() == pytest.approx(1.6e6)
+    assert traffic.average_flow_size_bytes() == pytest.approx(1_572_864.0)

--- a/utils/traffic.py
+++ b/utils/traffic.py
@@ -83,6 +83,20 @@ class GroundStationTraffic:
         self._active: Dict[int, _FlowState] = {}
 
     # ------------------------------------------------------------------
+    def average_flow_size_bytes(self) -> float:
+        """Return the mean flow size for the configured Pareto distribution."""
+
+        if self.pareto_shape <= 1.0:
+            raise ValueError("pareto_shape must be > 1 for a finite mean")
+        return self.pareto_scale_bytes * self.pareto_shape / (self.pareto_shape - 1.0)
+
+    # ------------------------------------------------------------------
+    def average_rate_bps(self) -> float:
+        """Return the configured per-flow transmission rate in bits/s."""
+
+        return self.rate_bps
+
+    # ------------------------------------------------------------------
     def _sample_size_bits(self) -> float:
         scale = self.pareto_scale_bytes * 8.0
         return scale * self.rng.paretovariate(self.pareto_shape)
@@ -149,6 +163,20 @@ class GroundStationPoissonTraffic:
         self.rng = random.Random(seed)
         self._next_id = 0
         self._active: Dict[int, List[_FlowState]] = {gs.id: [] for gs in self.stations}
+
+    # ------------------------------------------------------------------
+    def average_flow_size_bytes(self) -> float:
+        """Return the mean flow size for the configured Pareto distribution."""
+
+        if self.pareto_shape <= 1.0:
+            raise ValueError("pareto_shape must be > 1 for a finite mean")
+        return self.pareto_scale_bytes * self.pareto_shape / (self.pareto_shape - 1.0)
+
+    # ------------------------------------------------------------------
+    def average_rate_bps(self) -> float:
+        """Return the configured per-flow transmission rate in bits/s."""
+
+        return self.rate_bps
 
     # ------------------------------------------------------------------
     def _sample_size_bits(self) -> float:


### PR DESCRIPTION
## Summary
- add helper methods to traffic models to compute average flow size and rate
- provide script to print flow statistics
- cover new utilities with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfcb179dd8832b854daaa6ae9ae372