### PR TITLE
Log sampled flow sizes for Poisson traffic generator

### DIFF
--- a/scripts/run_shortest_path.py
+++ b/scripts/run_shortest_path.py
@@ -124,6 +124,7 @@ def main() -> None:
         pareto_shape=1.5,
         pareto_scale_bytes=512 * 1024,
         mean_flows_per_min=5.0,
+        verbose=True,
     )
 
     dt_s = float(cfg.step_seconds)

--- a/utils/traffic.py
+++ b/utils/traffic.py
@@ -154,6 +154,7 @@ class GroundStationPoissonTraffic:
         mean_flows_per_min: float = 5.0,
         stations: Sequence[GroundStation] = GROUND_STATIONS,
         seed: Optional[int] = None,
+        verbose: bool = False,
     ) -> None:
         self.rate_bps = rate_bps
         self.pareto_shape = pareto_shape
@@ -163,6 +164,7 @@ class GroundStationPoissonTraffic:
         self.rng = random.Random(seed)
         self._next_id = 0
         self._active: Dict[int, List[_FlowState]] = {gs.id: [] for gs in self.stations}
+        self.verbose = verbose
 
     # ------------------------------------------------------------------
     def average_flow_size_bytes(self) -> float:
@@ -205,7 +207,13 @@ class GroundStationPoissonTraffic:
             num_new = self._poisson(lam)
             for _ in range(num_new):
                 dst = self._pick_dst(gs.id)
-                st = _FlowState(id=self._next_id, dst=dst, remaining_bits=self._sample_size_bits())
+                size_bits = self._sample_size_bits()
+                st = _FlowState(id=self._next_id, dst=dst, remaining_bits=size_bits)
+                if self.verbose:
+                    size_bytes = size_bits / 8.0
+                    print(
+                        f"Generated flow {st.id} from GS{gs.id} to GS{dst} with Pareto size {size_bytes:.0f} bytes"
+                    )
                 self._next_id += 1
                 active_list.append(st)
 


### PR DESCRIPTION
## Summary
- add optional verbose flag to GroundStationPoissonTraffic to print Pareto-sampled flow sizes when new flows are generated
- enable verbose logging in run_shortest_path baseline so flow sizes are shown during execution

## Testing
- `pytest -q`
- `pip install networkx` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcea28e0c832bb19720caceb02be3