### PR TITLE
Boost Poisson traffic intensity and silence flow logging

### DIFF
--- a/scripts/flow_stats.py
+++ b/scripts/flow_stats.py
@@ -7,8 +7,8 @@ def main() -> None:
     traffic = GroundStationPoissonTraffic(
         rate_bps=1.6e6,
         pareto_shape=1.5,
-        pareto_scale_bytes=512 * 1024,
-        mean_flows_per_min=5.0,
+        pareto_scale_bytes=640 * 1024,
+        mean_flows_per_min=60.0,
     )
     avg_size = traffic.average_flow_size_bytes()
     avg_rate = traffic.average_rate_bps()

--- a/scripts/run_shortest_path.py
+++ b/scripts/run_shortest_path.py
@@ -122,9 +122,8 @@ def main() -> None:
     traffic = GroundStationPoissonTraffic(
         rate_bps=1.6e6,
         pareto_shape=1.5,
-        pareto_scale_bytes=512 * 1024,
-        mean_flows_per_min=5.0,
-        verbose=True,
+        pareto_scale_bytes=640 * 1024,
+        mean_flows_per_min=60.0,
     )
 
     dt_s = float(cfg.step_seconds)

--- a/tests/test_flow_stats.py
+++ b/tests/test_flow_stats.py
@@ -9,8 +9,6 @@ from utils import GroundStationPoissonTraffic
 
 
 def test_average_flow_stats():
-    traffic = GroundStationPoissonTraffic(
-        rate_bps=1.6e6, pareto_shape=1.5, pareto_scale_bytes=512 * 1024
-    )
+    traffic = GroundStationPoissonTraffic(rate_bps=1.6e6, pareto_shape=1.5)
     assert traffic.average_rate_bps() == pytest.approx(1.6e6)
-    assert traffic.average_flow_size_bytes() == pytest.approx(1_572_864.0)
+    assert traffic.average_flow_size_bytes() == pytest.approx(1_966_080.0)

--- a/utils/traffic.py
+++ b/utils/traffic.py
@@ -150,11 +150,10 @@ class GroundStationPoissonTraffic:
         self,
         rate_bps: float,
         pareto_shape: float,
-        pareto_scale_bytes: float = 512 * 1024,
-        mean_flows_per_min: float = 5.0,
+        pareto_scale_bytes: float = 640 * 1024,
+        mean_flows_per_min: float = 60.0,
         stations: Sequence[GroundStation] = GROUND_STATIONS,
         seed: Optional[int] = None,
-        verbose: bool = False,
     ) -> None:
         self.rate_bps = rate_bps
         self.pareto_shape = pareto_shape
@@ -164,7 +163,6 @@ class GroundStationPoissonTraffic:
         self.rng = random.Random(seed)
         self._next_id = 0
         self._active: Dict[int, List[_FlowState]] = {gs.id: [] for gs in self.stations}
-        self.verbose = verbose
 
     # ------------------------------------------------------------------
     def average_flow_size_bytes(self) -> float:
@@ -209,11 +207,6 @@ class GroundStationPoissonTraffic:
                 dst = self._pick_dst(gs.id)
                 size_bits = self._sample_size_bits()
                 st = _FlowState(id=self._next_id, dst=dst, remaining_bits=size_bits)
-                if self.verbose:
-                    size_bytes = size_bits / 8.0
-                    print(
-                        f"Generated flow {st.id} from GS{gs.id} to GS{dst} with Pareto size {size_bytes:.0f} bytes"
-                    )
                 self._next_id += 1
                 active_list.append(st)
 


### PR DESCRIPTION
## Summary
- Raise default Pareto scale to 640KiB and Poisson arrival rate to 60 flows/min
- Remove flow creation logging from Poisson traffic generator
- Update scripts and tests to new traffic defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd07d0370832bb7c9d699b5ce7247