### PR TITLE
Refactor Poisson traffic and centralize experiment configuration

### DIFF
--- a/configs/experiment.json
+++ b/configs/experiment.json
@@ -1,0 +1,39 @@
+{
+  "shortest_path": {
+    "constellation": {
+      "altitude_km": 550.0,
+      "inclination_deg": 53.0,
+      "num_sats": 172,
+      "step_seconds": 60,
+      "num_steps": 200,
+      "epoch_iso": "2025-08-08T04:00:00",
+      "bandwidth_mhz": 25.0
+    },
+    "traffic": {
+      "pareto_shape": 1.5,
+      "pareto_scale_bytes": 655360,
+      "mean_flows_per_min": 60.0
+    },
+    "algo": {
+      "beta": 0.5,
+      "steps": 200
+    }
+  },
+  "mappo": {
+    "env": {
+      "num_sats": 172,
+      "num_steps": 200,
+      "step_seconds": 60,
+      "num_flows": 2,
+      "flow_rate_bps": 1600000,
+      "packet_size_bytes": 1500,
+      "queue_cap_pkts": 640,
+      "retransmissions": 3,
+      "w1": 0.5,
+      "w2": 0.5
+    },
+    "rewiring": {
+      "mode": "none"
+    }
+  }
+}

--- a/scripts/flow_stats.py
+++ b/scripts/flow_stats.py
@@ -5,7 +5,6 @@ from utils import GroundStationPoissonTraffic
 
 def main() -> None:
     traffic = GroundStationPoissonTraffic(
-        rate_bps=1.6e6,
         pareto_shape=1.5,
         pareto_scale_bytes=640 * 1024,
         mean_flows_per_min=60.0,

--- a/scripts/run_mappo.py
+++ b/scripts/run_mappo.py
@@ -28,11 +28,12 @@ def main():
     args = parser.parse_args()
 
     cfg_all = load_config(args.config)
-    env = build_env(cfg_all["env"])
-    n_agents = cfg_all["env"]["num_sats"]
+    cfg_root = cfg_all.get("mappo", cfg_all)
+    env = build_env(cfg_root["env"])
+    n_agents = cfg_root["env"]["num_sats"]
     algo = MAPPO(env, n_agents, MAPPOConfig())
 
-    rew_cfg = cfg_all.get("rewiring", {"mode": "none"})
+    rew_cfg = cfg_root.get("rewiring", {"mode": "none"})
     rewirer = None
     if rew_cfg.get("mode") != "none" and CurvRewirer is not None:
         rewirer = CurvRewirer(**{k: v for k, v in rew_cfg.items() if k != "mode"})

--- a/tests/test_flow_stats.py
+++ b/tests/test_flow_stats.py
@@ -9,6 +9,6 @@ from utils import GroundStationPoissonTraffic
 
 
 def test_average_flow_stats():
-    traffic = GroundStationPoissonTraffic(rate_bps=1.6e6, pareto_shape=1.5)
-    assert traffic.average_rate_bps() == pytest.approx(1.6e6)
+    traffic = GroundStationPoissonTraffic(pareto_shape=1.5)
+    assert traffic.average_rate_bps() == pytest.approx(15_728_640.0)
     assert traffic.average_flow_size_bytes() == pytest.approx(1_966_080.0)


### PR DESCRIPTION
## Summary
- Remove explicit `rate_bps` from `GroundStationPoissonTraffic`; flow rate is now derived from sampled size and timestep
- Load shortest-path baseline and MAPPO training parameters from a shared JSON config
- Add a unified `configs/experiment.json` for different algorithm settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfdec0e284832bb2d9df611ff531c7