### PR TITLE
Fix bandwidth override in shortest path script

### DIFF
--- a/scripts/run_shortest_path.py
+++ b/scripts/run_shortest_path.py
@@ -135,8 +135,13 @@ def main() -> None:
     # Override the constellation bandwidth to 500 MHz.  Link capacities are
     # expressed in bits/s (Mbps when reported) so this only affects the
     # spectral bandwidth term in ``link_capacity_jsac``.
-    const_cfg = ConstellationConfig(**cfg_root["constellation"])
-    const_cfg.bandwidth_mhz = 500.0
+    # ``ConstellationConfig`` is a ``NamedTuple`` and therefore immutable.  The
+    # previous code attempted to mutate the ``bandwidth_mhz`` field after
+    # instantiation which raised ``AttributeError: can't set attribute``.  Build
+    # the configuration with the desired override instead.
+    const_kwargs = dict(cfg_root["constellation"])
+    const_kwargs["bandwidth_mhz"] = 500.0
+    const_cfg = ConstellationConfig(**const_kwargs)
     builder = TopologyBuilder(const_cfg)
 
     # Each simulation step represents one minute of traffic.  The Pareto


### PR DESCRIPTION
## Summary
- Fix AttributeError in `run_shortest_path.py` by rebuilding `ConstellationConfig` with a 500MHz bandwidth override

## Testing
- `pytest -q`
- `python -m py_compile scripts/run_shortest_path.py`
- ⚠️ `python scripts/run_shortest_path.py --config /tmp/test_short_config.json` *(failed: ModuleNotFoundError: No module named 'networkx')*


------
https://chatgpt.com/codex/tasks/task_e_68c00c23af10832b9875706946d1dd70