### PR TITLE
Add ground-station traffic and episodic training to graph PR MARL

### DIFF
--- a/marl/mappo.py
+++ b/marl/mappo.py
@@ -229,10 +229,13 @@ class MAPPO:
         return actions, torch.tensor(action_idx, dtype=torch.long), torch.tensor(logps, dtype=torch.float32)
 
     # ------------------------------------------------------------------
-    def rollout(self, T: int, rewirer=None) -> Tuple[RolloutBuffer, List[Dict[str, float]]]:
+    def rollout(self, T: int, rewirer=None, reset: bool = True) -> Tuple[RolloutBuffer, List[Dict[str, float]]]:
         buf = RolloutBuffer()
         metrics: List[Dict[str, float]] = []
-        G_phys = self.env.reset()
+        if reset:
+            G_phys = self.env.reset()
+        else:
+            G_phys = self.env.G_phys
         for t in range(T):
             if rewirer is None:
                 G_logic = G_phys


### PR DESCRIPTION
## Summary
- Replace fixed satellite flows with Poisson ground-station traffic shared with `run_shortest_path`
- Allow MAPPO rollouts without resetting environment to support 200-step episodes with 50-step updates
- Update graph PR training script defaults and episode handling

## Testing
- `python -m py_compile marl/env.py marl/mappo.py scripts/run_graphpr_marl.py`
- `python scripts/run_graphpr_marl.py --updates 1 --rollout 50` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c0f8e8e398832baaa35266c1a6b547