### PR TITLE
Fix embedding dimensions for policy head and critic

### DIFF
--- a/marl/mappo.py
+++ b/marl/mappo.py
@@ -142,12 +142,9 @@ class MAPPO:
         d_x = 6
         d_e = 6
         self.actor_backbone = GATBackbone(d_x=d_x, d_e=d_e)
-        self.policy_head = PolicyHead(d_in=self.actor_backbone.layers[-1].W.out_features // self.actor_backbone.layers[-1].heads, d_e=d_e)
-        self.critic = CentralisedCritic(
-            d_emb=self.actor_backbone.layers[-1].W.out_features
-            * self.actor_backbone.layers[-1].heads,
-            n_agents=n_agents,
-        )
+        emb_dim = self.actor_backbone.layers[-1].W.out_features
+        self.policy_head = PolicyHead(d_in=emb_dim, d_e=d_e)
+        self.critic = CentralisedCritic(d_emb=emb_dim, n_agents=n_agents)
         self.opt_actor = torch.optim.Adam(self.actor_backbone.parameters(), lr=cfg.lr_actor)
         self.opt_critic = torch.optim.Adam(self.critic.parameters(), lr=cfg.lr_critic)
 

--- a/scripts/run_graphpr_marl.py
+++ b/scripts/run_graphpr_marl.py
@@ -33,12 +33,9 @@ def main():
     algo.ob_builder = ObservationBuilder(L=2)
     d_x, d_e = 6, 6
     algo.actor_backbone = GATBackbone(d_x=d_x, d_e=d_e, L=2)
-    d_in = algo.actor_backbone.layers[-1].W.out_features // algo.actor_backbone.layers[-1].heads
-    algo.policy_head = PolicyHead(d_in=d_in, d_e=d_e)
-    algo.critic = CentralisedCritic(
-        d_emb=algo.actor_backbone.layers[-1].W.out_features * algo.actor_backbone.layers[-1].heads,
-        n_agents=n_agents,
-    )
+    emb_dim = algo.actor_backbone.layers[-1].W.out_features
+    algo.policy_head = PolicyHead(d_in=emb_dim, d_e=d_e)
+    algo.critic = CentralisedCritic(d_emb=emb_dim, n_agents=n_agents)
     algo.opt_actor = torch.optim.Adam(algo.actor_backbone.parameters(), lr=cfg.lr_actor)
     algo.opt_critic = torch.optim.Adam(algo.critic.parameters(), lr=cfg.lr_critic)
 


### PR DESCRIPTION
## Summary
- Correct MAPPO initialisation to derive embedding dimension without head scaling
- Align run_graphpr_marl script with new embedding dimension handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c115bcaa54832bb8bba41193257530