### PR TITLE
Add training progress logs and reward formula

### DIFF
--- a/scripts/run_mappo.py
+++ b/scripts/run_mappo.py
@@ -38,9 +38,12 @@ def main():
     if rew_cfg.get("mode") != "none" and CurvRewirer is not None:
         rewirer = CurvRewirer(**{k: v for k, v in rew_cfg.items() if k != "mode"})
 
-    for _ in range(args.updates):
+    for upd in range(args.updates):
         buf, _ = algo.rollout(args.rollout, rewirer=rewirer)
-        algo.update(buf)
+        pol_loss, val_loss = algo.update(buf)
+        print(
+            f"Update {upd + 1}/{args.updates}: policy loss={pol_loss:.4f} value loss={val_loss:.4f}"
+        )
     print("training completed")
 
 


### PR DESCRIPTION
## Summary
- log update number, policy loss, and value loss during MAPPO training
- apply flow-level reward: 0.5*(throughput/1e9) - 0.5*(latency)

## Testing
- `python -m pytest -q`
- `python scripts/run_curvmarl.py --config configs/exp1_no_rewire.json --updates 1 --rollout 1` *(fails: ModuleNotFoundError: No module named 'networkx')*
- `pip install networkx -q` *(fails: Could not find a version that satisfies the requirement networkx due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1190486a8832bad7e8fbec6668467