### PR TITLE
Add GraphPR model saving and evaluation script

### DIFF
--- a/scripts/run_graphpr_eval.py
+++ b/scripts/run_graphpr_eval.py
@@ -13,19 +13,13 @@ from marl.mappo import MAPPO, MAPPOConfig, CentralisedCritic
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--updates", type=int, default=2000)
-    parser.add_argument("--rollout", type=int, default=50)
-    parser.add_argument(
-        "--save-model",
-        type=str,
-        default="graphpr_model.pt",
-        help="Path to save the trained model",
-    )
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument("--steps", type=int, default=200)
     args = parser.parse_args()
 
     env_cfg = EnvConfig(
         num_sats=720,
-        num_steps=200,
+        num_steps=args.steps,
         altitude_km=570.0,
         inclination_deg=70.0,
     )
@@ -35,7 +29,7 @@ def main():
     cfg = MAPPOConfig(lr_actor=1e-4, lr_critic=1e-4)
     algo = MAPPO(env, n_agents, cfg)
 
-    # override networks for 2-hop observation and 2-layer GAT
+    # replicate network setup from training
     algo.ob_builder = ObservationBuilder(L=2)
     d_x, d_e = 6, 6
     algo.actor_backbone = GATBackbone(d_x=d_x, d_e=d_e, L=2)
@@ -45,20 +39,16 @@ def main():
     algo.opt_actor = torch.optim.Adam(algo.actor_backbone.parameters(), lr=cfg.lr_actor)
     algo.opt_critic = torch.optim.Adam(algo.critic.parameters(), lr=cfg.lr_critic)
 
-    plrs = []
-    delays_ms = []
-    throughputs = []
+    ckpt = torch.load(args.model, map_location="cpu")
+    algo.actor_backbone.load_state_dict(ckpt["actor"])
+    algo.policy_head.load_state_dict(ckpt["policy"])
+    algo.critic.load_state_dict(ckpt.get("critic", {}))
 
-    env.reset()
-    for _ in range(args.updates):
-        buf, metrics = algo.rollout(args.rollout, reset=False)
-        algo.update(buf)
-        for m in metrics:
-            plrs.append(m.get("packet_loss_rate", 0.0))
-            delays_ms.append(m.get("avg_delivery_time_s", 0.0) * 1000.0)
-            throughputs.append(m.get("system_throughput_Mbps", 0.0))
-        if env.step_idx >= env_cfg.num_steps:
-            env.reset()
+    _, metrics = algo.rollout(args.steps)
+
+    plrs = [m.get("packet_loss_rate", 0.0) for m in metrics]
+    delays_ms = [m.get("avg_delivery_time_s", 0.0) * 1000.0 for m in metrics]
+    throughputs = [m.get("system_throughput_Mbps", 0.0) for m in metrics]
 
     avg_plr = sum(plrs) / len(plrs) if plrs else 0.0
     avg_delay = sum(delays_ms) / len(delays_ms) if delays_ms else 0.0
@@ -67,17 +57,6 @@ def main():
     print(f"Average packet loss rate over {len(plrs)} steps: {avg_plr:.2f}%")
     print(f"Average end-to-end delay over {len(delays_ms)} steps: {avg_delay:.3f} ms")
     print(f"Average system throughput over {len(throughputs)} steps: {avg_thr:.3f} Mbps")
-
-    torch.save(
-        {
-            "actor": algo.actor_backbone.state_dict(),
-            "policy": algo.policy_head.state_dict(),
-            "critic": algo.critic.state_dict(),
-        },
-        args.save_model,
-    )
-
-    print(f"model saved to {args.save_model}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `run_graphpr_marl.py` to save trained model weights via `--save-model`
- add `run_graphpr_eval.py` to load a saved model and report packet loss, delay, and throughput over a rollout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c11a00283c832b87310617a3b492ef